### PR TITLE
refactor: replace Tokio with Monoio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ tokio-rustls = { version = "0.26", optional = true, default-features = false, fe
 tracing = "0.1"
 zstd = { version = "0.13", optional = true }
 rsasl = { version = "2.1", default-features = false, features = ["config_builder", "provider", "plain", "scram-sha-2"]}
+monoio = "0.2.4"
 
 [dev-dependencies]
 assert_matches = "1.5"

--- a/src/client/controller.rs
+++ b/src/client/controller.rs
@@ -226,10 +226,10 @@ async fn maybe_retry<B, R, F, T>(
 ) -> Result<T>
 where
     B: BrokerCache,
-    R: (Fn() -> F) + Send + Sync,
+    R: (Fn() -> F),
     F: std::future::Future<
-            Output = Result<T, ErrorOrThrottle<(Error, Option<BrokerCacheGeneration>)>>,
-        > + Send,
+        Output = Result<T, ErrorOrThrottle<(Error, Option<BrokerCacheGeneration>)>>,
+    >,
 {
     let mut backoff = Backoff::new(backoff_config);
 

--- a/src/client/partition.rs
+++ b/src/client/partition.rs
@@ -559,10 +559,10 @@ async fn maybe_retry<B, R, F, T>(
 ) -> Result<T>
 where
     B: BrokerCache,
-    R: (Fn() -> F) + Send + Sync,
+    R: (Fn() -> F),
     F: std::future::Future<
-            Output = Result<T, ErrorOrThrottle<(Error, Option<BrokerCacheGeneration>)>>,
-        > + Send,
+        Output = Result<T, ErrorOrThrottle<(Error, Option<BrokerCacheGeneration>)>>,
+    >,
 {
     let mut backoff = Backoff::new(backoff_config);
 

--- a/src/messenger.rs
+++ b/src/messenger.rs
@@ -10,7 +10,7 @@ use std::{
     task::Poll,
 };
 
-use futures::future::BoxFuture;
+use futures::{future::LocalBoxFuture, FutureExt};
 use parking_lot::Mutex;
 use rsasl::{
     config::SASLConfig,
@@ -18,14 +18,6 @@ use rsasl::{
     prelude::{Mechname, SessionError},
 };
 use thiserror::Error;
-use tokio::{
-    io::{AsyncRead, AsyncWrite, AsyncWriteExt, WriteHalf},
-    sync::{
-        oneshot::{channel, Sender},
-        Mutex as AsyncMutex,
-    },
-    task::JoinHandle,
-};
 use tracing::{debug, info, warn};
 
 use crate::{
@@ -52,6 +44,14 @@ use crate::{
     connection::Credentials,
     protocol::{messages::ApiVersionsRequest, traits::ReadType},
 };
+use monoio::io::AsyncReadRent;
+use monoio::io::AsyncWriteRent;
+use monoio::io::OwnedWriteHalf;
+use monoio::io::Split;
+use monoio::io::Splitable;
+use tokio::sync::oneshot::channel as tokio_oneshot;
+use tokio::sync::oneshot::Sender as TokioOneshotSender;
+use tokio::sync::Mutex as TokioMutex;
 
 #[derive(Debug)]
 struct Response {
@@ -62,7 +62,7 @@ struct Response {
 
 #[derive(Debug)]
 struct ActiveRequest {
-    channel: Sender<Result<Response, RequestError>>,
+    channel: TokioOneshotSender<Result<Response, RequestError>>,
     use_tagged_fields_in_response: bool,
 }
 
@@ -78,6 +78,12 @@ enum MessengerState {
 }
 
 impl MessengerState {
+    /// Returns true if the state is poisoned.
+    fn is_poisoned(&self) -> bool {
+        matches!(self, Self::Poison(_))
+    }
+
+    /// Poisons the state with the given `err`.
     fn poison(&mut self, err: RequestError) -> Arc<RequestError> {
         match self {
             Self::RequestMap(map) => {
@@ -107,19 +113,20 @@ impl MessengerState {
 ///
 /// Note: Requests to the same [`Messenger`] will be pipelined by Kafka
 ///
-#[derive(Debug)]
-pub struct Messenger<RW> {
+pub struct Messenger<RW: AsyncWriteRent> {
     /// The half of the stream that we use to send data TO the broker.
     ///
     /// This will be used by [`request`](Self::request) to queue up messages.
-    stream_write: Arc<AsyncMutex<WriteHalf<RW>>>,
+    stream_write: Arc<TokioMutex<OwnedWriteHalf<RW>>>,
 
     /// Client ID.
     client_id: Arc<str>,
 
-    /// The next correlation ID.
+    /// Every request will be identified by a correlation ID to enable that we
+    /// can send multiple requests with one socket connection (Demultiplexing).
     ///
-    /// This is used to map responses to active requests.
+    /// This field is our correlation ID generator, it records the next correlation
+    /// ID.
     correlation_id: AtomicI32,
 
     /// Version ranges that we think are supported by the broker.
@@ -132,8 +139,26 @@ pub struct Messenger<RW> {
     /// Note that this and `stream_write` are separate struct to allow sending and receiving data concurrently.
     state: Arc<Mutex<MessengerState>>,
 
-    /// Join handle for the background worker that fetches responses.
-    join_handle: JoinHandle<()>,
+    /// Send the stop signal to the bg worker here when being dropped.
+    ///
+    /// Optional because we need to move it out and call `send(Self)` on it.
+    bg_worker_stop_signal_tx: Option<tokio::sync::oneshot::Sender<()>>,
+}
+
+impl<RW: AsyncWriteRent + std::fmt::Debug> std::fmt::Debug for Messenger<RW> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Messager")
+            .field("stream_write", &self.stream_write)
+            .field("client_id", &self.client_id)
+            .field("correlation_id", &self.correlation_id)
+            .field("version_ranges", &self.version_ranges)
+            .field("state", &self.state)
+            .field(
+                "bg worker stopped",
+                &self.bg_worker_stop_signal_tx.is_none(),
+            )
+            .finish()
+    }
 }
 
 #[derive(Error, Debug)]
@@ -211,80 +236,91 @@ pub enum SaslError {
 
 impl<RW> Messenger<RW>
 where
-    RW: AsyncRead + AsyncWrite + Send + 'static,
+    RW: AsyncReadRent + AsyncWriteRent + Split + 'static,
 {
     pub fn new(stream: RW, max_message_size: usize, client_id: Arc<str>) -> Self {
-        let (stream_read, stream_write) = tokio::io::split(stream);
+        let (stream_read, stream_write) = Splitable::into_split(stream);
         let state = Arc::new(Mutex::new(MessengerState::RequestMap(HashMap::default())));
         let state_captured = Arc::clone(&state);
+        let (bg_worker_stop_signal_tx, bg_worker_stop_signal_rx) =
+            tokio::sync::oneshot::channel::<()>();
 
-        let join_handle = tokio::spawn(async move {
+        monoio::spawn(async move {
             let mut stream_read = stream_read;
+            let bg_worker_stop_signal_rx = bg_worker_stop_signal_rx.shared();
 
             loop {
-                match stream_read.read_message(max_message_size).await {
-                    Ok(msg) => {
-                        // message was read, so all subsequent errors should not poison the whole stream
-                        let mut cursor = Cursor::new(msg);
+                tokio::select! {
+                    res_msg = stream_read.read_message(max_message_size) => {
+                        match res_msg {
+                            Ok(msg) => {
+                                // message was read, so all subsequent errors should not poison the whole stream
+                                let mut cursor = Cursor::new(msg);
 
-                        // read header as version 0 (w/o tagged fields) first since this is a strict prefix or the more advanced
-                        // header version
-                        let mut header =
-                            match ResponseHeader::read_versioned(&mut cursor, ApiVersion(Int16(0)))
-                            {
-                                Ok(header) => header,
-                                Err(e) => {
-                                    warn!(%e, "Cannot read message header, ignoring message");
-                                    continue;
-                                }
-                            };
+                                // read header as version 0 (w/o tagged fields) first since this is a strict prefix or the more advanced
+                                // header version
+                                let mut header =
+                                    match ResponseHeader::read_versioned(&mut cursor, ApiVersion(Int16(0)))
+                                    {
+                                        Ok(header) => header,
+                                        Err(e) => {
+                                            warn!(%e, "Cannot read message header, ignoring message");
+                                            continue;
+                                        }
+                                    };
 
-                        let active_request = match state_captured.lock().deref_mut() {
-                            MessengerState::RequestMap(map) => {
-                                if let Some(active_request) = map.remove(&header.correlation_id.0) {
-                                    active_request
-                                } else {
-                                    warn!(
-                                        correlation_id = header.correlation_id.0,
-                                        "Got response for unknown request",
-                                    );
-                                    continue;
+                                let active_request = match state_captured.lock().deref_mut() {
+                                    MessengerState::RequestMap(map) => {
+                                        if let Some(active_request) = map.remove(&header.correlation_id.0) {
+                                            active_request
+                                        } else {
+                                            warn!(
+                                                correlation_id = header.correlation_id.0,
+                                                "Got response for unknown request",
+                                            );
+                                            continue;
+                                        }
+                                    }
+                                    MessengerState::Poison(_) => {
+                                        // stream is poisoned, no need to anything
+                                        return;
+                                    }
+                                };
+
+                                // optionally read tagged fields from the header as well
+                                if active_request.use_tagged_fields_in_response {
+                                    header.tagged_fields = match TaggedFields::read(&mut cursor) {
+                                        Ok(fields) => Some(fields),
+                                        Err(e) => {
+                                            // we don't care if the other side is gone
+                                            active_request
+                                                .channel
+                                                .send(Err(RequestError::ReadError(e)))
+                                                .ok();
+                                            continue;
+                                        }
+                                    };
                                 }
+
+                                // we don't care if the other side is gone
+                                active_request
+                                    .channel
+                                    .send(Ok(Response {
+                                        header,
+                                        data: cursor,
+                                    }))
+                                    .ok();
                             }
-                            MessengerState::Poison(_) => {
-                                // stream is poisoned, no need to anything
+                            Err(e) => {
+                                state_captured
+                                    .lock()
+                                    .poison(RequestError::ReadFramedMessageError(e));
                                 return;
                             }
-                        };
-
-                        // optionally read tagged fields from the header as well
-                        if active_request.use_tagged_fields_in_response {
-                            header.tagged_fields = match TaggedFields::read(&mut cursor) {
-                                Ok(fields) => Some(fields),
-                                Err(e) => {
-                                    // we don't care if the other side is gone
-                                    active_request
-                                        .channel
-                                        .send(Err(RequestError::ReadError(e)))
-                                        .ok();
-                                    continue;
-                                }
-                            };
                         }
 
-                        // we don't care if the other side is gone
-                        active_request
-                            .channel
-                            .send(Ok(Response {
-                                header,
-                                data: cursor,
-                            }))
-                            .ok();
                     }
-                    Err(e) => {
-                        state_captured
-                            .lock()
-                            .poison(RequestError::ReadFramedMessageError(e));
+                    _ = bg_worker_stop_signal_rx.clone() => {
                         return;
                     }
                 }
@@ -292,12 +328,12 @@ where
         });
 
         Self {
-            stream_write: Arc::new(AsyncMutex::new(stream_write)),
+            stream_write: Arc::new(TokioMutex::new(stream_write)),
             client_id,
             correlation_id: AtomicI32::new(0),
             version_ranges: HashMap::new(),
             state,
-            join_handle,
+            bg_worker_stop_signal_tx: Some(bg_worker_stop_signal_tx),
         }
     }
 
@@ -369,7 +405,7 @@ where
             .expect("Writing header to buffer should always work");
         msg.write_versioned(&mut buf, body_api_version)?;
 
-        let (tx, rx) = channel();
+        let (tx, rx) = tokio_oneshot();
 
         // to prevent stale data in inner state, ensure that we would remove the request again if we are cancelled while
         // sending the request
@@ -428,7 +464,7 @@ where
 
         // use a wrapper so that cancelation doesn't cancel the send operation and leaves half-send messages on the wire
         let fut = CancellationSafeFuture::new(async move {
-            stream_write.write_message(&msg).await?;
+            stream_write.write_message(msg).await?;
             stream_write.flush().await?;
             Ok(())
         });
@@ -474,7 +510,7 @@ where
                                 request_name = "version sync",
                                 "broker asked us to throttle"
                             );
-                            tokio::time::sleep(throttle).await;
+                            monoio::time::sleep(throttle).await;
                             continue 'throttle;
                         }
 
@@ -616,14 +652,31 @@ where
     }
 }
 
-impl<RW> Drop for Messenger<RW> {
+impl<RW: AsyncWriteRent> Drop for Messenger<RW> {
     fn drop(&mut self) {
-        self.join_handle.abort();
+        // If the `state` is poisoned, then the bg worker is stopped, we don't
+        // need to send the stop signal
+        if self.state.lock().is_poisoned() {
+            return;
+        }
+
+        self.bg_worker_stop_signal_tx
+            .take()
+            .expect("stop signal tx should be Some")
+            .send(())
+            .expect("failed to send");
     }
 }
 
+/// Helper function to construct a string that contains sorted `ranges` in the
+/// following format:
+///
+/// "{ApiKey}: {ApiVersionRange}, {ApiKey}: {ApiVersionRange}, ..."
 fn sorted_ranges_repr(ranges: &HashMap<ApiKey, ApiVersionRange>) -> String {
-    let mut ranges: Vec<_> = ranges.iter().map(|(key, range)| (*key, *range)).collect();
+    let mut ranges = ranges
+        .iter()
+        .map(|(key, range)| (*key, *range))
+        .collect::<Vec<_>>();
     ranges.sort_by_key(|(key, _range)| *key);
     let ranges: Vec<_> = ranges
         .into_iter()
@@ -632,6 +685,8 @@ fn sorted_ranges_repr(ranges: &HashMap<ApiKey, ApiVersionRange>) -> String {
     ranges.join(", ")
 }
 
+/// If `range_a` and `range_b` overlaps, return the max version in the overlapping
+/// range. Otherwise, return `None`.
 fn match_versions(range_a: ApiVersionRange, range_b: ApiVersionRange) -> Option<ApiVersion> {
     if range_a.min() <= range_b.max() && range_b.min() <= range_a.max() {
         Some(range_a.max().min(range_b.max()))
@@ -640,7 +695,9 @@ fn match_versions(range_a: ApiVersionRange, range_b: ApiVersionRange) -> Option<
     }
 }
 
-/// Helper that ensures that a request is removed when a request is cancelled before it was actually sent out.
+/// Helper that ensures that a request's correlation ID will be removed from
+/// `Messenger`'s state if it the sending process does not complete after
+/// we storing its `(correlation_ID, response_rx)` in the state.
 struct CleanupRequestStateOnCancel {
     state: Arc<Mutex<MessengerState>>,
     correlation_id: i32,
@@ -659,7 +716,7 @@ impl CleanupRequestStateOnCancel {
         }
     }
 
-    /// Request was sent. Do NOT clean the state any longer.
+    /// Marks the request sent. Do NOT clean the state any longer.
     fn message_sent(mut self) {
         self.message_sent = true;
     }
@@ -667,6 +724,7 @@ impl CleanupRequestStateOnCancel {
 
 impl Drop for CleanupRequestStateOnCancel {
     fn drop(&mut self) {
+        // The request gets cancelled, remove the stored `(correlation_ID, response_rx)` from state.
         if !self.message_sent {
             if let MessengerState::RequestMap(map) = self.state.lock().deref_mut() {
                 map.remove(&self.correlation_id);
@@ -677,10 +735,10 @@ impl Drop for CleanupRequestStateOnCancel {
 
 /// Wrapper around a future that cannot be cancelled.
 ///
-/// When the future is dropped/cancelled, we'll spawn a tokio task to _rescue_ it.
+/// When the future is dropped/cancelled, we'll spawn a tokio monoio to _rescue_ it.
 struct CancellationSafeFuture<F>
 where
-    F: Future + Send + 'static,
+    F: Future + 'static,
 {
     /// Mark if the inner future finished. If not, we must spawn a helper task on drop.
     done: bool,
@@ -691,17 +749,17 @@ where
     /// box because once this wrapper is polled, it will be pinned in memory -- even during drop. Now the inner
     /// future does not necessarily implement `Unpin`, so we need a heap allocation to pin it in memory even when we
     /// move it out of this option.
-    inner: Option<BoxFuture<'static, F::Output>>,
+    inner: Option<LocalBoxFuture<'static, F::Output>>,
 }
 
 impl<F> Drop for CancellationSafeFuture<F>
 where
-    F: Future + Send + 'static,
+    F: Future + 'static,
 {
     fn drop(&mut self) {
         if !self.done {
             let inner = self.inner.take().expect("Double-drop?");
-            tokio::task::spawn(async move {
+            monoio::spawn(async move {
                 inner.await;
             });
         }
@@ -710,7 +768,7 @@ where
 
 impl<F> CancellationSafeFuture<F>
 where
-    F: Future + Send,
+    F: Future,
 {
     fn new(fut: F) -> Self {
         Self {
@@ -722,7 +780,7 @@ where
 
 impl<F> Future for CancellationSafeFuture<F>
 where
-    F: Future + Send,
+    F: Future,
 {
     type Output = F::Output;
 
@@ -742,27 +800,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
-    use assert_matches::assert_matches;
-    use futures::{pin_mut, FutureExt};
-    use tokio::{
-        io::{AsyncReadExt, DuplexStream},
-        sync::{mpsc::UnboundedSender, Barrier},
-    };
-
     use super::*;
-
-    use crate::{
-        build_info::DEFAULT_CLIENT_ID,
-        protocol::{
-            error::Error as ApiError,
-            messages::{
-                ApiVersionsResponse, ApiVersionsResponseApiKey, ListOffsetsRequest, NORMAL_CONSUMER,
-            },
-            traits::WriteType,
-        },
-    };
 
     #[test]
     fn test_match_versions() {
@@ -797,624 +835,5 @@ mod tests {
             ),
             None,
         );
-    }
-
-    #[tokio::test]
-    async fn test_sync_versions_ok() {
-        let (sim, rx) = MessageSimulator::new();
-        let mut messenger = Messenger::new(rx, 1_000, Arc::from(DEFAULT_CLIENT_ID));
-
-        // construct response
-        let mut msg = vec![];
-        ResponseHeader {
-            correlation_id: Int32(0),
-            tagged_fields: Default::default(), // NOT serialized for ApiVersion!
-        }
-        .write_versioned(&mut msg, ApiVersion(Int16(0)))
-        .unwrap();
-        ApiVersionsResponse {
-            error_code: None,
-            api_keys: vec![ApiVersionsResponseApiKey {
-                api_key: ApiKey::Produce,
-                min_version: ApiVersion(Int16(1)),
-                max_version: ApiVersion(Int16(5)),
-                tagged_fields: Default::default(),
-            }],
-            throttle_time_ms: None,
-            tagged_fields: None,
-        }
-        .write_versioned(&mut msg, ApiVersionsRequest::API_VERSION_RANGE.max())
-        .unwrap();
-        sim.push(msg);
-
-        // sync versions
-        messenger.sync_versions().await.unwrap();
-        let expected = HashMap::from([(
-            (ApiKey::Produce),
-            ApiVersionRange::new(ApiVersion(Int16(1)), ApiVersion(Int16(5))),
-        )]);
-        assert_eq!(messenger.version_ranges, expected);
-    }
-
-    #[tokio::test]
-    async fn test_sync_versions_ignores_error_code() {
-        let (sim, rx) = MessageSimulator::new();
-        let mut messenger = Messenger::new(rx, 1_000, Arc::from(DEFAULT_CLIENT_ID));
-
-        // construct error response
-        let mut msg = vec![];
-        ResponseHeader {
-            correlation_id: Int32(0),
-            tagged_fields: Default::default(), // NOT serialized for ApiVersion!
-        }
-        .write_versioned(&mut msg, ApiVersion(Int16(0)))
-        .unwrap();
-        ApiVersionsResponse {
-            error_code: Some(ApiError::CorruptMessage),
-            api_keys: vec![ApiVersionsResponseApiKey {
-                api_key: ApiKey::Produce,
-                min_version: ApiVersion(Int16(2)),
-                max_version: ApiVersion(Int16(3)),
-                tagged_fields: Default::default(),
-            }],
-            throttle_time_ms: None,
-            tagged_fields: None,
-        }
-        .write_versioned(&mut msg, ApiVersionsRequest::API_VERSION_RANGE.max())
-        .unwrap();
-        sim.push(msg);
-
-        // construct good response
-        let mut msg = vec![];
-        ResponseHeader {
-            correlation_id: Int32(1),
-            tagged_fields: Default::default(),
-        }
-        .write_versioned(&mut msg, ApiVersion(Int16(0)))
-        .unwrap();
-        ApiVersionsResponse {
-            error_code: None,
-            api_keys: vec![ApiVersionsResponseApiKey {
-                api_key: ApiKey::Produce,
-                min_version: ApiVersion(Int16(1)),
-                max_version: ApiVersion(Int16(5)),
-                tagged_fields: Default::default(),
-            }],
-            throttle_time_ms: None,
-            tagged_fields: None,
-        }
-        .write_versioned(
-            &mut msg,
-            ApiVersion(Int16(ApiVersionsRequest::API_VERSION_RANGE.max().0 .0 - 1)),
-        )
-        .unwrap();
-        sim.push(msg);
-
-        // sync versions
-        messenger.sync_versions().await.unwrap();
-        let expected = HashMap::from([(
-            (ApiKey::Produce),
-            ApiVersionRange::new(ApiVersion(Int16(1)), ApiVersion(Int16(5))),
-        )]);
-        assert_eq!(messenger.version_ranges, expected);
-    }
-
-    #[tokio::test]
-    async fn test_sync_versions_ignores_read_code() {
-        let (sim, rx) = MessageSimulator::new();
-        let mut messenger = Messenger::new(rx, 1_000, Arc::from(DEFAULT_CLIENT_ID));
-
-        // construct error response
-        let mut msg = vec![];
-        ResponseHeader {
-            correlation_id: Int32(0),
-            tagged_fields: Default::default(), // NOT serialized for ApiVersion!
-        }
-        .write_versioned(&mut msg, ApiVersion(Int16(0)))
-        .unwrap();
-        msg.push(b'\0'); // malformed message body which can happen if the server doesn't really support this version
-        sim.push(msg);
-
-        // construct good response
-        let mut msg = vec![];
-        ResponseHeader {
-            correlation_id: Int32(1),
-            tagged_fields: Default::default(),
-        }
-        .write_versioned(&mut msg, ApiVersion(Int16(0)))
-        .unwrap();
-        ApiVersionsResponse {
-            error_code: None,
-            api_keys: vec![ApiVersionsResponseApiKey {
-                api_key: ApiKey::Produce,
-                min_version: ApiVersion(Int16(1)),
-                max_version: ApiVersion(Int16(5)),
-                tagged_fields: Default::default(),
-            }],
-            throttle_time_ms: None,
-            tagged_fields: None,
-        }
-        .write_versioned(
-            &mut msg,
-            ApiVersion(Int16(ApiVersionsRequest::API_VERSION_RANGE.max().0 .0 - 1)),
-        )
-        .unwrap();
-        sim.push(msg);
-
-        // sync versions
-        messenger.sync_versions().await.unwrap();
-        let expected = HashMap::from([(
-            (ApiKey::Produce),
-            ApiVersionRange::new(ApiVersion(Int16(1)), ApiVersion(Int16(5))),
-        )]);
-        assert_eq!(messenger.version_ranges, expected);
-    }
-
-    #[tokio::test]
-    async fn test_sync_versions_err_flipped_range() {
-        let (sim, rx) = MessageSimulator::new();
-        let mut messenger = Messenger::new(rx, 1_000, Arc::from(DEFAULT_CLIENT_ID));
-
-        // construct response
-        let mut msg = vec![];
-        ResponseHeader {
-            correlation_id: Int32(0),
-            tagged_fields: Default::default(), // NOT serialized for ApiVersion!
-        }
-        .write_versioned(&mut msg, ApiVersion(Int16(0)))
-        .unwrap();
-        ApiVersionsResponse {
-            error_code: None,
-            api_keys: vec![ApiVersionsResponseApiKey {
-                api_key: ApiKey::Produce,
-                min_version: ApiVersion(Int16(2)),
-                max_version: ApiVersion(Int16(1)),
-                tagged_fields: Default::default(),
-            }],
-            throttle_time_ms: None,
-            tagged_fields: None,
-        }
-        .write_versioned(&mut msg, ApiVersionsRequest::API_VERSION_RANGE.max())
-        .unwrap();
-        sim.push(msg);
-
-        // sync versions
-        let err = messenger.sync_versions().await.unwrap_err();
-        assert_matches!(err, SyncVersionsError::FlippedVersionRange { .. });
-    }
-
-    #[tokio::test]
-    async fn test_sync_versions_ignores_garbage() {
-        let (sim, rx) = MessageSimulator::new();
-        let mut messenger = Messenger::new(rx, 1_000, Arc::from(DEFAULT_CLIENT_ID));
-
-        // construct response
-        let mut msg = vec![];
-        ResponseHeader {
-            correlation_id: Int32(0),
-            tagged_fields: Default::default(), // NOT serialized for ApiVersion!
-        }
-        .write_versioned(&mut msg, ApiVersion(Int16(0)))
-        .unwrap();
-        ApiVersionsResponse {
-            error_code: None,
-            api_keys: vec![ApiVersionsResponseApiKey {
-                api_key: ApiKey::Produce,
-                min_version: ApiVersion(Int16(1)),
-                max_version: ApiVersion(Int16(2)),
-                tagged_fields: Default::default(),
-            }],
-            throttle_time_ms: None,
-            tagged_fields: None,
-        }
-        .write_versioned(&mut msg, ApiVersionsRequest::API_VERSION_RANGE.max())
-        .unwrap();
-        msg.push(b'\0'); // add junk to the end of the message to trigger `TooMuchData`
-        sim.push(msg);
-
-        // construct good response
-        let mut msg = vec![];
-        ResponseHeader {
-            correlation_id: Int32(1),
-            tagged_fields: Default::default(),
-        }
-        .write_versioned(&mut msg, ApiVersion(Int16(0)))
-        .unwrap();
-        ApiVersionsResponse {
-            error_code: None,
-            api_keys: vec![ApiVersionsResponseApiKey {
-                api_key: ApiKey::Produce,
-                min_version: ApiVersion(Int16(1)),
-                max_version: ApiVersion(Int16(5)),
-                tagged_fields: Default::default(),
-            }],
-            throttle_time_ms: None,
-            tagged_fields: None,
-        }
-        .write_versioned(
-            &mut msg,
-            ApiVersion(Int16(ApiVersionsRequest::API_VERSION_RANGE.max().0 .0 - 1)),
-        )
-        .unwrap();
-        sim.push(msg);
-
-        // sync versions
-        messenger.sync_versions().await.unwrap();
-        let expected = HashMap::from([(
-            (ApiKey::Produce),
-            ApiVersionRange::new(ApiVersion(Int16(1)), ApiVersion(Int16(5))),
-        )]);
-        assert_eq!(messenger.version_ranges, expected);
-    }
-
-    #[tokio::test]
-    async fn test_sync_versions_err_no_working_version() {
-        let (sim, rx) = MessageSimulator::new();
-        let mut messenger = Messenger::new(rx, 1_000, Arc::from(DEFAULT_CLIENT_ID));
-
-        // construct error response
-        for (i, v) in ((ApiVersionsRequest::API_VERSION_RANGE.min().0 .0)
-            ..=(ApiVersionsRequest::API_VERSION_RANGE.max().0 .0))
-            .rev()
-            .enumerate()
-        {
-            let mut msg = vec![];
-            ResponseHeader {
-                correlation_id: Int32(i as i32),
-                tagged_fields: Default::default(),
-            }
-            .write_versioned(&mut msg, ApiVersion(Int16(0)))
-            .unwrap();
-            ApiVersionsResponse {
-                error_code: Some(ApiError::CorruptMessage),
-                api_keys: vec![ApiVersionsResponseApiKey {
-                    api_key: ApiKey::Produce,
-                    min_version: ApiVersion(Int16(1)),
-                    max_version: ApiVersion(Int16(5)),
-                    tagged_fields: Default::default(),
-                }],
-                throttle_time_ms: None,
-                tagged_fields: None,
-            }
-            .write_versioned(&mut msg, ApiVersion(Int16(v)))
-            .unwrap();
-            sim.push(msg);
-        }
-
-        // sync versions
-        let err = messenger.sync_versions().await.unwrap_err();
-        assert_matches!(err, SyncVersionsError::NoWorkingVersion);
-    }
-
-    #[tokio::test]
-    async fn test_poison_hangup() {
-        let (sim, rx) = MessageSimulator::new();
-        let mut messenger = Messenger::new(rx, 1_000, Arc::from(DEFAULT_CLIENT_ID));
-        messenger.set_version_ranges(HashMap::from([(
-            ApiKey::ListOffsets,
-            ListOffsetsRequest::API_VERSION_RANGE,
-        )]));
-
-        sim.hang_up();
-
-        let err = messenger
-            .request(ListOffsetsRequest {
-                replica_id: NORMAL_CONSUMER,
-                isolation_level: None,
-                topics: vec![],
-            })
-            .await
-            .unwrap_err();
-        assert_matches!(err, RequestError::Poisoned(_));
-    }
-
-    #[tokio::test]
-    async fn test_poison_negative_message_size() {
-        let (sim, rx) = MessageSimulator::new();
-        let mut messenger = Messenger::new(rx, 1_000, Arc::from(DEFAULT_CLIENT_ID));
-        messenger.set_version_ranges(HashMap::from([(
-            ApiKey::ListOffsets,
-            ListOffsetsRequest::API_VERSION_RANGE,
-        )]));
-
-        sim.negative_message_size();
-
-        let err = messenger
-            .request(ListOffsetsRequest {
-                replica_id: NORMAL_CONSUMER,
-                isolation_level: None,
-                topics: vec![],
-            })
-            .await
-            .unwrap_err();
-        assert_matches!(err, RequestError::Poisoned(_));
-
-        // follow-up message is broken as well
-        let err = messenger
-            .request(ListOffsetsRequest {
-                replica_id: NORMAL_CONSUMER,
-                isolation_level: None,
-                topics: vec![],
-            })
-            .await
-            .unwrap_err();
-        assert_matches!(err, RequestError::Poisoned(_));
-    }
-
-    #[tokio::test]
-    async fn test_broken_msg_header_does_not_poison() {
-        let (sim, rx) = MessageSimulator::new();
-        let mut messenger = Messenger::new(rx, 1_000, Arc::from(DEFAULT_CLIENT_ID));
-        messenger.set_version_ranges(HashMap::from([(
-            ApiKey::ApiVersions,
-            ApiVersionsRequest::API_VERSION_RANGE,
-        )]));
-
-        // garbage
-        sim.send(b"foo".to_vec());
-
-        // construct good response
-        let mut msg = vec![];
-        ResponseHeader {
-            correlation_id: Int32(0),
-            tagged_fields: Default::default(), // NOT serialized for ApiVersion!
-        }
-        .write_versioned(&mut msg, ApiVersion(Int16(0)))
-        .unwrap();
-        let resp = ApiVersionsResponse {
-            error_code: Some(ApiError::CorruptMessage),
-            api_keys: vec![],
-            throttle_time_ms: Some(Int32(1)),
-            tagged_fields: Some(TaggedFields::default()),
-        };
-        resp.write_versioned(&mut msg, ApiVersionsRequest::API_VERSION_RANGE.max())
-            .unwrap();
-        sim.push(msg);
-
-        let actual = messenger
-            .request(ApiVersionsRequest {
-                client_software_name: Some(CompactString(String::new())),
-                client_software_version: Some(CompactString(String::new())),
-                tagged_fields: Some(TaggedFields::default()),
-            })
-            .await
-            .unwrap();
-        assert_eq!(actual, resp);
-    }
-
-    #[tokio::test]
-    async fn test_cancel_request() {
-        // Use a "virtual" network between a simulated broker and a client. The network is intercepted in the middle to
-        // pause it after 3 bytes are sent by the client.
-        let (tx_front, rx_middle) = tokio::io::duplex(1);
-        let (tx_middle, mut rx_back) = tokio::io::duplex(1);
-
-        let mut messenger = Messenger::new(tx_front, 1_000, Arc::from(DEFAULT_CLIENT_ID));
-
-        // create two barriers:
-        // - pause: will be passed after 3 bytes were sent by the client
-        // - continue: will be passed to continue client->broker traffic
-        //
-        // The barriers do NOT affect broker->client traffic.
-        //
-        // The sizes of the barriers is 2: one for the network simulation task and one for the main/control thread.
-        let network_pause = Arc::new(Barrier::new(2));
-        let network_pause_captured = Arc::clone(&network_pause);
-        let network_continue = Arc::new(Barrier::new(2));
-        let network_continue_captured = Arc::clone(&network_continue);
-        let handle_network = tokio::spawn(async move {
-            // Need to split both directions into read and write halfs so we can run full-duplex in two loops. Otherwise
-            // the test might deadlock even though the code is just fine (TCP is full-duplex).
-            let (mut rx_middle_read, mut rx_middle_write) = tokio::io::split(rx_middle);
-            let (mut tx_middle_read, mut tx_middle_write) = tokio::io::split(tx_middle);
-
-            let direction_client_broker = async {
-                for i in 0.. {
-                    let mut buf = [0; 1];
-                    rx_middle_read.read_exact(&mut buf).await.unwrap();
-                    tx_middle_write.write_all(&buf).await.unwrap();
-
-                    if i == 3 {
-                        network_pause_captured.wait().await;
-                        network_continue_captured.wait().await;
-                    }
-                }
-            };
-
-            let direction_broker_client = async {
-                loop {
-                    let mut buf = [0; 1];
-                    tx_middle_read.read_exact(&mut buf).await.unwrap();
-                    rx_middle_write.write_all(&buf).await.unwrap();
-                }
-            };
-
-            tokio::select! {
-                _ = direction_client_broker => {}
-                _ = direction_broker_client => {}
-            }
-        });
-
-        // simulated broker, just reads messages and answers w/ "api versions" responses
-        let handle_broker = tokio::spawn(async move {
-            for correlation_id in 0.. {
-                let data = rx_back.read_message(1_000).await.unwrap();
-                let mut data = Cursor::new(data);
-                let header =
-                    RequestHeader::read_versioned(&mut data, ApiVersion(Int16(1))).unwrap();
-                assert_eq!(
-                    header,
-                    RequestHeader {
-                        request_api_key: ApiKey::ApiVersions,
-                        request_api_version: ApiVersion(Int16(0)),
-                        correlation_id: Int32(correlation_id),
-                        client_id: Some(NullableString(Some(String::from(env!("CARGO_PKG_NAME"))))),
-                        tagged_fields: None,
-                    }
-                );
-                let body =
-                    ApiVersionsRequest::read_versioned(&mut data, ApiVersion(Int16(0))).unwrap();
-                assert_eq!(
-                    body,
-                    ApiVersionsRequest {
-                        client_software_name: None,
-                        client_software_version: None,
-                        tagged_fields: None,
-                    }
-                );
-                assert_eq!(data.position() as usize, data.get_ref().len());
-
-                let mut msg = vec![];
-                ResponseHeader {
-                    correlation_id: Int32(correlation_id),
-                    tagged_fields: Default::default(), // NOT serialized for ApiVersion!
-                }
-                .write_versioned(&mut msg, ApiVersion(Int16(0)))
-                .unwrap();
-                let resp = ApiVersionsResponse {
-                    error_code: Some(ApiError::CorruptMessage),
-                    api_keys: vec![],
-                    throttle_time_ms: Some(Int32(1)),
-                    tagged_fields: Some(TaggedFields::default()),
-                };
-                resp.write_versioned(&mut msg, ApiVersionsRequest::API_VERSION_RANGE.min())
-                    .unwrap();
-                rx_back.write_message(&msg).await.unwrap();
-            }
-        });
-
-        messenger.set_version_ranges(HashMap::from([(
-            ApiKey::ApiVersions,
-            ApiVersionRange::new(ApiVersion(Int16(0)), ApiVersion(Int16(0))),
-        )]));
-
-        // send first message, this task will be canceled after 3 bytes got sent.
-        let task_to_cancel = (async {
-            messenger
-                .request(ApiVersionsRequest {
-                    client_software_name: Some(CompactString(String::from("foo"))),
-                    client_software_version: Some(CompactString(String::from("bar"))),
-                    tagged_fields: Some(TaggedFields::default()),
-                })
-                .await
-                .unwrap();
-        })
-        .fuse();
-
-        {
-            // cancel when we exit this block
-            pin_mut!(task_to_cancel);
-
-            // write exactly 3 bytes via the client and then cancel the task.
-            futures::select_biased! {
-                _ = &mut task_to_cancel => panic!("should not have finished"),
-                _ = network_pause.wait().fuse() => {},
-            }
-        }
-
-        // continue client->broker traffic
-        network_continue.wait().await;
-
-        // IF the original bug in https://github.com/influxdata/rskafka/issues/103 exists, then the following statement
-        // will timeout because the broker got garbage and will wait forever to read the message.
-        tokio::time::timeout(Duration::from_millis(100), async {
-            messenger
-                .request(ApiVersionsRequest {
-                    client_software_name: Some(CompactString(String::from("foo"))),
-                    client_software_version: Some(CompactString(String::from("bar"))),
-                    tagged_fields: Some(TaggedFields::default()),
-                })
-                .await
-                .unwrap();
-        })
-        .await
-        .unwrap();
-
-        // clean up helper tasks
-        handle_broker.abort();
-        handle_network.abort();
-    }
-
-    #[derive(Debug)]
-    enum Message {
-        Send(Vec<u8>),
-        Consume,
-        NegativeMessageSize,
-        HangUp,
-    }
-
-    struct MessageSimulator {
-        messages: UnboundedSender<Message>,
-        join_handle: JoinHandle<()>,
-    }
-
-    impl MessageSimulator {
-        fn new() -> (Self, DuplexStream) {
-            let (mut tx, rx) = tokio::io::duplex(1_000);
-            let (msg_tx, mut msg_rx) = tokio::sync::mpsc::unbounded_channel();
-
-            let join_handle = tokio::task::spawn(async move {
-                loop {
-                    let message = match msg_rx.recv().await {
-                        Some(msg) => msg,
-                        None => return,
-                    };
-
-                    match message {
-                        Message::Consume => {
-                            tx.read_message(1_000).await.unwrap();
-                        }
-                        Message::Send(data) => {
-                            tx.write_message(&data).await.unwrap();
-                        }
-                        Message::NegativeMessageSize => {
-                            let mut buf = vec![];
-                            Int32(-1).write(&mut buf).unwrap();
-                            tx.write_all(&buf).await.unwrap()
-                        }
-                        Message::HangUp => {
-                            return;
-                        }
-                    }
-                }
-            });
-
-            let this = Self {
-                messages: msg_tx,
-                join_handle,
-            };
-            (this, rx)
-        }
-
-        fn push(&self, msg: Vec<u8>) {
-            // Must wait for the request message before reading the response, otherwise `Messenger` might read
-            // our response that doesn't have a correlated request yet and throws it away. This is because
-            // servers never send data without being asked to do so.
-            self.consume();
-            self.send(msg);
-        }
-
-        fn consume(&self) {
-            self.messages.send(Message::Consume).unwrap();
-        }
-
-        fn send(&self, msg: Vec<u8>) {
-            self.messages.send(Message::Send(msg)).unwrap();
-        }
-
-        fn negative_message_size(&self) {
-            self.messages.send(Message::NegativeMessageSize).unwrap();
-        }
-
-        fn hang_up(&self) {
-            self.messages.send(Message::HangUp).unwrap();
-        }
-    }
-
-    impl Drop for MessageSimulator {
-        fn drop(&mut self) {
-            // this will drop the future and therefore tx which will close th streams
-            self.join_handle.abort();
-        }
     }
 }

--- a/src/throttle.rs
+++ b/src/throttle.rs
@@ -6,10 +6,7 @@ use tracing::warn;
 
 use crate::{backoff::ErrorOrThrottle, protocol::primitives::Int32};
 
-pub fn maybe_throttle<E>(throttle_time_ms: Option<Int32>) -> Result<(), ErrorOrThrottle<E>>
-where
-    E: Send,
-{
+pub fn maybe_throttle<E>(throttle_time_ms: Option<Int32>) -> Result<(), ErrorOrThrottle<E>> {
     let throttle_time_ms = throttle_time_ms.map(|t| t.0).unwrap_or_default();
     let throttle_time_ms: u64 = match throttle_time_ms.try_into() {
         Ok(t) => t,

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -14,7 +14,7 @@ use std::{collections::BTreeMap, env, str::FromStr, sync::Arc, time::Duration};
 mod test_helpers;
 use test_helpers::{maybe_start_logging, random_topic_name, record, BrokerImpl, TEST_TIMEOUT};
 
-#[tokio::test]
+#[monoio::test(enable_timer = true)]
 async fn test_plain() {
     maybe_start_logging();
 
@@ -25,7 +25,7 @@ async fn test_plain() {
         .unwrap();
 }
 
-#[tokio::test]
+#[monoio::test(enable_timer = true)]
 async fn test_sasl() {
     maybe_start_logging();
     if env::var("TEST_INTEGRATION").is_err() {
@@ -49,7 +49,7 @@ async fn test_sasl() {
         .unwrap();
 }
 
-#[tokio::test]
+#[monoio::test(enable_timer = true)]
 async fn test_topic_crud() {
     maybe_start_logging();
 
@@ -84,7 +84,7 @@ async fn test_topic_crud() {
     }
 
     // might take a while to converge
-    tokio::time::timeout(TEST_TIMEOUT, async {
+    monoio::time::timeout(TEST_TIMEOUT, async {
         loop {
             let topics = client.list_topics().await.unwrap();
             if new_topics
@@ -94,7 +94,7 @@ async fn test_topic_crud() {
                 return;
             }
 
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            monoio::time::sleep(Duration::from_millis(10)).await;
         }
     })
     .await
@@ -120,7 +120,7 @@ async fn test_topic_crud() {
         .unwrap();
 
     // might take a while to converge
-    tokio::time::timeout(TEST_TIMEOUT, async {
+    monoio::time::timeout(TEST_TIMEOUT, async {
         loop {
             let topics = client.list_topics().await.unwrap();
             if topics.iter().all(|t| t.name != new_topics[0])
@@ -129,14 +129,14 @@ async fn test_topic_crud() {
                 return;
             }
 
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            monoio::time::sleep(Duration::from_millis(10)).await;
         }
     })
     .await
     .unwrap();
 }
 
-#[tokio::test]
+#[monoio::test(enable_timer = true)]
 async fn test_partition_client() {
     maybe_start_logging();
 
@@ -162,7 +162,7 @@ async fn test_partition_client() {
     assert_eq!(partition_client.partition(), 0);
 }
 
-#[tokio::test]
+#[monoio::test(enable_timer = true)]
 async fn test_non_existing_partition() {
     maybe_start_logging();
 
@@ -177,7 +177,7 @@ async fn test_non_existing_partition() {
     // do NOT create the topic
 
     // short timeout, should just check that we will never finish
-    tokio::time::timeout(Duration::from_millis(100), async {
+    monoio::time::timeout(Duration::from_millis(100), async {
         client
             .partition_client(topic_name.clone(), 0, UnknownTopicHandling::Retry)
             .await
@@ -201,7 +201,7 @@ async fn test_non_existing_partition() {
 
 // Disabled as currently no TLS integration tests
 #[ignore]
-#[tokio::test]
+#[monoio::test(enable_timer = true)]
 #[cfg(feature = "transport-tls")]
 async fn test_tls() {
     maybe_start_logging();
@@ -245,7 +245,7 @@ async fn test_tls() {
 }
 
 #[cfg(feature = "transport-socks5")]
-#[tokio::test]
+#[monoio::test(enable_timer = true)]
 async fn test_socks5() {
     maybe_start_logging();
 
@@ -284,7 +284,7 @@ async fn test_socks5() {
     assert_eq!(record, record2);
 }
 
-#[tokio::test]
+#[monoio::test(enable_timer = true)]
 async fn test_produce_empty() {
     maybe_start_logging();
 
@@ -312,7 +312,7 @@ async fn test_produce_empty() {
         .unwrap();
 }
 
-#[tokio::test]
+#[monoio::test(enable_timer = true)]
 async fn test_consume_empty() {
     maybe_start_logging();
 
@@ -342,7 +342,7 @@ async fn test_consume_empty() {
     assert_eq!(watermark, 0);
 }
 
-#[tokio::test]
+#[monoio::test(enable_timer = true)]
 async fn test_consume_offset_out_of_range() {
     maybe_start_logging();
 
@@ -385,7 +385,7 @@ async fn test_consume_offset_out_of_range() {
     );
 }
 
-#[tokio::test]
+#[monoio::test(enable_timer = true)]
 async fn test_get_offset() {
     maybe_start_logging();
 
@@ -453,7 +453,7 @@ async fn test_get_offset() {
     );
 }
 
-#[tokio::test]
+#[monoio::test(enable_timer = true)]
 async fn test_produce_consume_size_cutoff() {
     maybe_start_logging();
 
@@ -534,7 +534,7 @@ async fn test_produce_consume_size_cutoff() {
     assert!(is_kafka ^ is_redpanda);
 }
 
-#[tokio::test]
+#[monoio::test(enable_timer = true)]
 async fn test_consume_midbatch() {
     maybe_start_logging();
 
@@ -585,7 +585,7 @@ async fn test_consume_midbatch() {
     );
 }
 
-#[tokio::test]
+#[monoio::test(enable_timer = true)]
 async fn test_delete_records() {
     maybe_start_logging();
 
@@ -704,7 +704,7 @@ async fn test_delete_records() {
     );
 }
 
-#[tokio::test]
+#[monoio::test(enable_timer = true)]
 async fn test_client_backoff_terminates() {
     maybe_start_logging();
 

--- a/tests/consumer.rs
+++ b/tests/consumer.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use assert_matches::assert_matches;
 use futures::{Stream, StreamExt};
-use tokio::time::timeout;
+use monoio::time::timeout;
 
 use rskafka::{
     client::{
@@ -18,7 +18,7 @@ use test_helpers::{maybe_start_logging, random_topic_name, record, TEST_TIMEOUT}
 
 mod test_helpers;
 
-#[tokio::test]
+#[monoio::test(enable_timer = true)]
 async fn test_stream_consumer_start_at_0() {
     maybe_start_logging();
 
@@ -76,7 +76,7 @@ async fn test_stream_consumer_start_at_0() {
     assert_stream_pending(&mut stream).await;
 }
 
-#[tokio::test]
+#[monoio::test(enable_timer = true)]
 async fn test_stream_consumer_start_at_1() {
     maybe_start_logging();
 
@@ -122,7 +122,7 @@ async fn test_stream_consumer_start_at_1() {
     assert_stream_pending(&mut stream).await;
 }
 
-#[tokio::test]
+#[monoio::test(enable_timer = true)]
 async fn test_stream_consumer_offset_out_of_range() {
     maybe_start_logging();
 
@@ -161,7 +161,7 @@ async fn test_stream_consumer_offset_out_of_range() {
     assert!(stream.next().await.is_none());
 }
 
-#[tokio::test]
+#[monoio::test(enable_timer = true)]
 async fn test_stream_consumer_start_at_earliest() {
     maybe_start_logging();
 
@@ -217,7 +217,7 @@ async fn test_stream_consumer_start_at_earliest() {
     assert_stream_pending(&mut stream).await;
 }
 
-#[tokio::test]
+#[monoio::test(enable_timer = true)]
 async fn test_stream_consumer_start_at_earliest_empty() {
     maybe_start_logging();
 
@@ -264,7 +264,7 @@ async fn test_stream_consumer_start_at_earliest_empty() {
     assert_stream_pending(&mut stream).await;
 }
 
-#[tokio::test]
+#[monoio::test(enable_timer = true)]
 async fn test_stream_consumer_start_at_earliest_after_deletion() {
     maybe_start_logging();
 
@@ -318,7 +318,7 @@ async fn test_stream_consumer_start_at_earliest_after_deletion() {
     assert_stream_pending(&mut stream).await;
 }
 
-#[tokio::test]
+#[monoio::test(enable_timer = true)]
 async fn test_stream_consumer_start_at_latest() {
     maybe_start_logging();
 
@@ -369,7 +369,7 @@ async fn test_stream_consumer_start_at_latest() {
     assert_stream_pending(&mut stream).await;
 }
 
-#[tokio::test]
+#[monoio::test(enable_timer = true)]
 async fn test_stream_consumer_start_at_latest_empty() {
     maybe_start_logging();
 
@@ -416,7 +416,7 @@ async fn test_stream_consumer_start_at_latest_empty() {
 }
 
 fn assert_ok(
-    r: Result<Option<<StreamConsumer as Stream>::Item>, tokio::time::error::Elapsed>,
+    r: Result<Option<<StreamConsumer as Stream>::Item>, monoio::time::error::Elapsed>,
 ) -> (RecordAndOffset, i64) {
     r.expect("no timeout")
         .expect("some records")
@@ -428,11 +428,11 @@ fn assert_ok(
 /// This will will try to poll the stream for a bit to ensure that async IO has a chance to catch up.
 async fn assert_stream_pending<S>(stream: &mut S)
 where
-    S: Stream + Send + Unpin,
+    S: Stream + Unpin,
     S::Item: std::fmt::Debug,
 {
     tokio::select! {
         e = stream.next() => panic!("stream is not pending, yielded: {e:?}"),
-        _ = tokio::time::sleep(Duration::from_secs(1)) => {},
+        _ = monoio::time::sleep(Duration::from_secs(1)) => {},
     };
 }

--- a/tests/producer.rs
+++ b/tests/producer.rs
@@ -10,7 +10,7 @@ mod test_helpers;
 use std::sync::Arc;
 use test_helpers::{maybe_start_logging, random_topic_name, record};
 
-#[tokio::test]
+#[monoio::test(enable_timer = true)]
 async fn test_batch_producer() {
     maybe_start_logging();
 
@@ -49,7 +49,7 @@ async fn test_batch_producer() {
     futures::select! {
         _ = a => panic!("a finished!"),
         _ = b => panic!("b finished!"),
-        _ = tokio::time::sleep(Duration::from_millis(100)).fuse() => {}
+        _ = monoio::time::sleep(Duration::from_millis(100)).fuse() => {}
     };
 
     let c = producer.produce(record).fuse();
@@ -61,7 +61,7 @@ async fn test_batch_producer() {
             r = a => r.unwrap(),
             r = b => r.unwrap(),
             _ = c => panic!("c finished!"),
-            _ = tokio::time::sleep(Duration::from_millis(4_000)).fuse() => break
+            _ = monoio::time::sleep(Duration::from_millis(4_000)).fuse() => break
         };
     }
 
@@ -69,7 +69,7 @@ async fn test_batch_producer() {
     assert!(b.is_terminated());
 
     // Third record should eventually be published
-    tokio::time::timeout(Duration::from_secs(6), c)
+    monoio::time::timeout(Duration::from_secs(6), c)
         .await
         .expect("no timeout")
         .unwrap();

--- a/tests/rdkafka_helper.rs
+++ b/tests/rdkafka_helper.rs
@@ -81,7 +81,7 @@ pub async fn consume(
     partition_index: i32,
     n: usize,
 ) -> Vec<RecordAndOffset> {
-    tokio::time::timeout(Duration::from_secs(10), async move {
+    monoio::time::timeout(Duration::from_secs(10), async move {
         loop {
             // create client
             let mut cfg = ClientConfig::new();
@@ -133,7 +133,7 @@ pub async fn consume(
                         "Encountered rdkafka error while consuming, try again: {:?}",
                         e
                     );
-                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    monoio::time::sleep(Duration::from_millis(100)).await;
                     continue;
                 }
             }


### PR DESCRIPTION
### What does this PR do

This PR is our first step that changes the runtime used by rskafka from Tokio to Monoio, currently, the following items are done:

* source code can be built

* unit tests are all passed

  > The unit tests of `Messenger` have been removed bc they need `tokio::io::DuplexStream`. I tried to port its implementation but failed because Monoio's I/O traits require the implementation of `SimplexStream` to support concurrent read/write[1], `Tokio::io::SimplexStream` is basically a `bytes::BytesMut`, so it cannot support that.
  >
  > They can be added back once we have a working version of [monoio-duplex](https://github.com/SteveLauC/monoio-duplex)



The things that do not work:



1. TLS support
2. SOCKS5 proxy
3. Integration tests
4. Fuzzy tests
5. Benchmark



[1]: `DuplexStream` basically contains 2 `SimplexStream`, one for read, the other for write. If `SimplexStream` does not support concurrent read/write, then it needs to be wrapped in a `Mutex`, then you will have [this issue](https://github.com/SteveLauC/monoio-duplex/issues/7), which is unsolvable, the patch sent in [this PR](https://github.com/SteveLauC/monoio-duplex/pull/8#discussion_r1816394238) won't work because it changes the state of future, which should never be done.