### PR TITLE
refactor: make Error types Send/Sync

### DIFF
--- a/src/backoff.rs
+++ b/src/backoff.rs
@@ -26,7 +26,7 @@ impl Default for BackoffConfig {
     }
 }
 
-type SourceError = Box<dyn std::error::Error>;
+type SourceError = Box<dyn std::error::Error + std::marker::Send + std::marker::Sync>;
 
 #[derive(Debug, thiserror::Error)]
 #[allow(missing_copy_implementations)]
@@ -105,7 +105,7 @@ impl Backoff {
     where
         F: (Fn() -> F1),
         F1: std::future::Future<Output = ControlFlow<B, ErrorOrThrottle<E>>>,
-        E: std::error::Error + 'static,
+        E: std::error::Error + std::marker::Send + std::marker::Sync + 'static,
     {
         loop {
             // split match statement from `monoio::time::sleep`, because otherwise rustc requires `B: Send`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
     clippy::clone_on_ref_ptr,
     clippy::disallowed_methods
 )]
+#![allow(clippy::future_not_send)]
 
 mod backoff;
 


### PR DESCRIPTION
Describe your proposed changes here.

Make the Error types `Send` and `Sync` because:

1. Needed by Pizza
2. Having error types `!Send` and `!Sync` does not make too much sense in most cases
